### PR TITLE
Fix preferred input device not being used when AirPods are detected

### DIFF
--- a/AirPods Sanity/AirPodsObserver.swift
+++ b/AirPods Sanity/AirPodsObserver.swift
@@ -51,7 +51,7 @@ private extension AirPodsObserver
 			return
 		}
 
-		guard let __NewInputDeviceName = self._DefaultInputDeviceName != nil ? self._DefaultInputDeviceName : self._Preferences.InputDeviceName else { return }
+		guard let __NewInputDeviceName = self._Preferences.InputDeviceName != nil ? self._Preferences.InputDeviceName : self._DefaultInputDeviceName else { return }
 		guard let __InputDevice = self._Simply.allInputDevices.filter({ $0.name == __NewInputDeviceName }).first else { return }
 
 		if __DefaultInputDevice.id != __InputDevice.id


### PR DESCRIPTION
Previously, the app would prioritize a temporarily stored device name over the user's configured preferred input device, causing it to switch to the wrong microphone (e.g., MacBook Pro Microphone instead of Wireless Microphone RX) when AirPods were connected.